### PR TITLE
Updated links and product name

### DIFF
--- a/DNSHealth/MailProviders/BarracudaESS.json
+++ b/DNSHealth/MailProviders/BarracudaESS.json
@@ -1,8 +1,8 @@
 {
-    "Name": "Barracuda Email Security Service",
-    "_MxComment": "https://campus.barracuda.com/product/essentials/doc/86545480/step-2-configure-office-365-for-inbound-and-outbound-mail/",
+    "Name": "Barracuda Email Gateway Defense",
+    "_MxComment": "https://campus.barracuda.com/product/emailgatewaydefense/doc/167976430/step-2-configure-microsoft-365-for-inbound-and-outbound-mail",
     "MxMatch": "ess(?<Country>.[a-z]{2})?.barracudanetworks.com",
-    "_SpfComment": "https://campus.barracuda.com/product/essentials/doc/73702276/sender-policy-framework-for-outbound-mail",
+    "_SpfComment": "https://campus.barracuda.com/product/emailgatewaydefense/doc/167976840/sender-policy-framework-for-outbound-mail",
     "SpfInclude": "spf.ess{0}.barracudanetworks.com",
     "SpfReplace": ["Country"],
     "_DkimComment": "No configuration found",


### PR DESCRIPTION
Barracuda has moved away from the essentials product selling plans and are no longer updating the old documentation.

```
As of March 1, 2022, the legacy Barracuda Essentials Security, Compliance, and Complete editions are no longer available for purchase. Only existing customers can renew or add users to these plans.

Following October 30, 2022, the documentation and trainings will no longer be updated and will contain outdated information.
```

New SPF link includes the India region.

Renamed product to "Barracuda Email Gateway Defense"