### PR TITLE
fix: detect Mimecast South Africa, USB and Offshore MX regions

### DIFF
--- a/DNSHealth/MailProviders/Mimecast.json
+++ b/DNSHealth/MailProviders/Mimecast.json
@@ -1,6 +1,6 @@
 {
     "Name": "Mimecast",
-    "MxMatch": "(?<Prefix>[a-z]{2})-smtp-inbound-[0-9].mimecast.com",
+    "MxMatch": "^(?<Prefix>[a-z]{2,3})-smtp-inbound-[0-9]\\.mimecast\\.(?:com|co\\.za)",
     "SpfInclude": "{0}._netblocks.mimecast.com",
     "SpfReplace": [ "Prefix" ],
     "Selectors": [],

--- a/DNSHealth/MailProviders/MimecastOffshore.json
+++ b/DNSHealth/MailProviders/MimecastOffshore.json
@@ -1,0 +1,10 @@
+{
+    "Name": "Mimecast Offshore",
+    "MxMatch": "^(?<Prefix>[a-z]{2,3})-smtp-inbound-[0-9]\\.mimecast-offshore\\.com",
+    "SpfInclude": "",
+    "SpfReplace": [],
+    "Selectors": [],
+    "_MxComment": "https://community.mimecast.com/s/article/Connect-Application-Modifying-Your-MX-Records-673313100",
+    "_SpfComment": "Offshore (Jersey) region netblock include is not publicly documented; leave empty so no incorrect SPF include is asserted.",
+    "_DkimComment": "https://community.mimecast.com/s/article/DNS-Authentication-Configuration-Guide-345109074"
+}


### PR DESCRIPTION
The Mimecast MxMatch only recognised the two-letter *.mimecast.com hostnames, so three documented regions were never identified by the domain analyser:

- South Africa uses za-smtp-inbound-N.mimecast.co.za (different TLD).
- The US (B) region uses a three-letter prefix (usb-), which the [a-z]{2} class mis-captured as 'sb'.
- Offshore (Jersey) uses *.mimecast-offshore.com.

Broaden the prefix to 2-3 chars, anchor the match, and accept the .co.za TLD; the za prefix still resolves the SPF include to za._netblocks.mimecast.com, which is the include those domains publish. Add a separate Mimecast Offshore provider for *.mimecast-offshore.com with an empty SpfInclude, because that region's netblock host is not publicly documented and every candidate resolves NXDOMAIN - leaving it empty skips SPF-include validation rather than asserting a wrong expected include.